### PR TITLE
Fix service/2 return spec

### DIFF
--- a/lib/cassette/plug/authentication_handler.ex
+++ b/lib/cassette/plug/authentication_handler.ex
@@ -44,7 +44,7 @@ defmodule Cassette.Plug.AuthenticationHandler do
 
   Usually this is the URL of the page the user is trying to access and may be computed using values in `conn`
   """
-  @callback service(conn :: Conn.t(), options :: term) :: Conn.t()
+  @callback service(conn :: Conn.t(), options :: term) :: String.t()
 
   @doc """
   Called when there is no authentication in the request (i.e., no `ticket` in the query string).

--- a/lib/cassette/plug/authentication_handler.ex
+++ b/lib/cassette/plug/authentication_handler.ex
@@ -91,7 +91,7 @@ defmodule Cassette.Plug.AuthenticationHandler do
       @doc """
       Builds the current request url to be used as the CAS service
       """
-      @spec service(conn :: Conn.t(), options :: term) :: Conn.t()
+      @spec service(conn :: Conn.t(), options :: term) :: String.t()
       def service(conn, options) do
         url(conn, options)
       end


### PR DESCRIPTION
Small fix for this warning 
```
[.. Dialyzer] The inferred return type of service/2 (binary()) 
has nothing in common with #{'__struct__':='Elixir.Plug.Conn', .... }, 
which is the expected return type for the callback of the 
'Elixir.Cassette.Plug.AuthenticationHandler' behaviour
```
when `@impl Cassette.Plug.AuthenticationHandler`