### PR TITLE
Fixing a bug in typespec.

### DIFF
--- a/lib/cassette/plug.ex
+++ b/lib/cassette/plug.ex
@@ -57,7 +57,7 @@ defmodule Cassette.Plug do
   alias Plug.Conn
   alias Plug.Builder
 
-  @type options :: [cassette: Cassette.Support, handler: AuthenticationHandler]
+  @type options :: [cassette: module(), handler: module()]
 
   @spec init([]) :: []
   @doc "Initializes this plug"


### PR DESCRIPTION
Hi there! We've been enjoying using Cassette.Plug to get SSO support in our elixir apps, but I noticed an issue when our dialyzer runs started to fail.

The type spec for the init options was specified in such a way that it was invalid (according to the spec) to pass anything but `Cassette.Support` as the value for `cassette` and anything but `AuthenticationHandler` as the value for `handler`. 

As a result, any project using Cassette.Plug and overriding those defaults (like we do) will have dialyzer errors. Instead of hard-coding the values in the spec, it should just specify that those values should be module names.